### PR TITLE
LATIR 6: Link Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "fundacionlatir.org",
   "dependencies": {
     "@juan-utils/functions": "^2.3.0",
+    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "fundacionlatir.org",
   "dependencies": {
     "@juan-utils/functions": "^2.3.0",
-    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router": "^5.1.2",

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import styled from 'styled-components'
+import { useHistory } from 'react-router-dom'
+import PropTypes from 'prop-types'
+
+import Colors from '../../utils/colors';
+
+const LinkWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0px 6px;
+    color: ${Colors.White.hexString()}
+`
+
+const LinkStyle = styled.a`
+    padding: 6px;
+    color: inherit;
+    text-decoration: none;
+    font-size: 1em;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+`
+
+const Link = ({ to , children , text , replace }) => {
+    const history = useHistory();
+    const handleClick = () => replace ? history.replace(to) : history.push(to);
+    return <LinkWrapper>
+        <LinkStyle onClick={handleClick}>{children || text}</LinkStyle>
+    </LinkWrapper>
+}
+
+Link.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element
+    ]),
+    text: PropTypes.string,
+    to: PropTypes.string.isRequired,
+    replace: PropTypes.bool,
+}
+
+export default Link;

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { useHistory } from 'react-router-dom'
-import PropTypes from 'prop-types'
 
 import Colors from '../../utils/colors';
 
@@ -25,22 +24,27 @@ const LinkStyle = styled.a`
     }
 `
 
-const Link = ({ to , children , text , replace }) => {
+/**
+ * @typedef {{
+ *  to: string;
+ *  children?: string;
+ *  text?: string;
+ *  replace?: boolean;
+ *  onClick?: (e: any) => void;
+ * }} LinkProps
+ * @param {LinkProps} props
+ * @description A link element that on click, moves to the 'to' route. Requires either a text prop or children
+ * @returns {JSX.Element} anchor html tag
+ */
+const Link = ({ to , children , text , replace , onClick }) => {
     const history = useHistory();
-    const handleClick = () => replace ? history.replace(to) : history.push(to);
+    const handleClick = (e) => {
+        onClick && onClick(e)
+        replace ? history.replace(to) : history.push(to);
+    }
     return <LinkWrapper>
         <LinkStyle onClick={handleClick}>{children || text}</LinkStyle>
     </LinkWrapper>
-}
-
-Link.propTypes = {
-    children: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element
-    ]),
-    text: PropTypes.string,
-    to: PropTypes.string.isRequired,
-    replace: PropTypes.bool,
 }
 
 export default Link;

--- a/src/components/Navbar/WideView/index.js
+++ b/src/components/Navbar/WideView/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { identity } from '@juan-utils/functions';
-import { useHistory } from 'react-router-dom';
 
 import Colors from '../../../utils/colors';
 import LogoIcon from '../../LogoIcon';
 import NoSelect from '../../NoSelect';
+import Link from '../../Link';
 
 const LinkContainer = styled.nav`
     margin: 6px;
@@ -15,26 +15,6 @@ const LinkContainer = styled.nav`
     align-items: center;
     justify-content: flex-start;
 ` 
-
-const LinkWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0px 6px;
-    color: ${Colors.White.hexString()}
-`
-
-const LinkStyle = styled.a`
-    padding: 6px;
-    color: inherit;
-    text-decoration: none;
-    font-size: 1em;
-    cursor: pointer;
-
-    &:hover {
-        text-decoration: underline;
-    }
-`
 
 const WideLogoContainer = styled.header`
     display: flex;
@@ -47,31 +27,15 @@ const WideLogoContainer = styled.header`
     user-select: none;
 `
 
-const Link = ({ to , children }) => {
-    const history = useHistory();
-    const handleClick = () => {
-        history.push(to);
-    }
-    return <LinkStyle onClick={handleClick}>{children}</LinkStyle>
-}
-
 const Links = () => (
     <LinkContainer>
-        <LinkWrapper>
-            <Link to="/">¿Quiénes Somos?</Link>
-        </LinkWrapper>
+        <Link to="/">¿Quiénes Somos?</Link>
         <NoSelect>|</NoSelect>
-        <LinkWrapper>
-            <Link to="/">¿Qué hacemos?</Link>
-        </LinkWrapper>
+        <Link to="/">¿Qué hacemos?</Link>
         <NoSelect>|</NoSelect>
-        <LinkWrapper>
-            <Link to="/">¿Cómo lo hacemos?</Link> 
-        </LinkWrapper>
+        <Link to="/">¿Cómo lo hacemos?</Link> 
         <NoSelect>|</NoSelect>
-        <LinkWrapper>
-            <Link to="/">Rendición de Cuentas</Link> 
-        </LinkWrapper>
+        <Link to="/">Rendición de Cuentas</Link> 
     </LinkContainer>
 )
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 // Here we should export all components for easy access
 export { default as AppContainer } from './AppContainer'; 
 export { default as HamburgerButton } from './HamburgerButton';
+export { default as Link } from './Link'
 export { default as Navbar } from './Navbar';
 export { default as NoSelect } from './NoSelect';


### PR DESCRIPTION
closes #6 

This creates a Link component. Not using react-router Link to add styling
This PR has a need of a decision. Either we use [PropTypes](https://www.npmjs.com/package/prop-types) or simply use jsdoc to document components. 

__Proptypes Approach:__

__Pros:__
- Runtime checking of the types of props
- Enforces those types

__Cons:__
- Has no way to actually say what the component does
- VSCode adds it to the type of components creating noise

__JSDoc Approach:__

__Pros:__
- Since it is documentation, we can add a description on how to use the component
- Uses typescript to type the component
- VSCode can read that information and show it to the user quite nicely

__Cons:__
- Does not enforce anything
- No way around making noise in the code
- Since we are not in typescript, complex types and library especific types are a bit difficult to add

Please give me opinions about this issue because I am unsure what to do. For the time being the JSDoc option is the one used but if you move to the previous commit, the proptypes option is used.
Whichever is decided will be added to the readme afterwards. Use the comments to give me your opinions guys.

__Final Decision__

Taking into account the comments, we will use JSDoc to document components